### PR TITLE
Updated reference to the TFTP script

### DIFF
--- a/badger.ps1
+++ b/badger.ps1
@@ -128,7 +128,7 @@ Switch -regex ($bit){
 		
 		#this part is a copy of switch 'e'
         write-host $e1 # start tftp + 2 agonizing mins
-        . '.\bits\TFTP flash old Tmo FW via subnet 29.ps1'
+        . '.\bits\TFTP flash old Tmo FW via current subnet.ps1'
 		write-host -foregroundcolor green $e3 # enable ssh instructions
         pause
     }


### PR DESCRIPTION
Main script was pointing to 'TFTP flash old Tmo FW via subnet 29.ps1' while current name of the file it is trying to run is 'TFTP flash old Tmo FW via current subnet.ps1' causing file not found error. This updates the reference to the TFTP script.